### PR TITLE
Fixed first compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Cloudwalk CLI is the CLI to create, pack, run and test posxml and DaFunk project
     - [Docker Compose](https://docs.docker.com/compose/install/)
 
 - Docker Setup
+  - `git submodule update --init`
   - `docker-compose build`
+  - `docker-compose run da_funk`
   - `docker-compose run all`
 
 Each app will be generated with a Dockerfile that inherits a base image. You can pull the image from docker hub here: https://registry.hub.docker.com/u/scalone/cloudwalk-cli/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Cloudwalk CLI is the CLI to create, pack, run and test posxml and DaFunk project
     - [Docker Compose](https://docs.docker.com/compose/install/)
 
 - Docker Setup
-  - `git submodule update --init`
   - `docker-compose build`
   - `docker-compose run da_funk`
   - `docker-compose run all`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ bintest:
 mtest:
   <<: *defaults
   command: /bin/bash -l -c "rake test:mtest"
+da_funk:
+  <<: *defaults
+  command: /bin/bash -l -c "rake da_funk"
 bundle:
   <<: *defaults
   command: /bin/bash -l -c "bundle install"


### PR DESCRIPTION
The information on readme was broken, in order to compile correct first, we need to initialise main submodule. After that, it was needed to build da_funk.c in src and a compiled version of da_funk.